### PR TITLE
Add per-rule debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Quick starting guide for new plugin devs:
 - `npm i` or `yarn` to install dependencies.
 - `npm run dev` to start compilation in watch mode.
 
+When configuring rules in the plugin settings, each rule includes a **Debug** toggle. When enabled, the plugin will show a notification such as `DEBUG: NOTE_NAME would be moved to Vault/Folder/Subfolder` instead of moving the note.
+
 ## Manually installing the plugin
 
 - Copy over `main.js`, `styles.css`, `manifest.json` to your vault `VaultFolder/.obsidian/plugins/your-plugin-id/`.

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import {
     TAbstractFile,
     TFile,
     normalizePath,
+    Notice,
 } from 'obsidian';
 import {
     FrontmatterRule,
@@ -50,6 +51,12 @@ export default class VaultOrganizer extends Plugin {
 
                 const newPath = normalizePath(`${rule.destination}/${file.name}`);
                 if (file.path === newPath) {
+                    return;
+                }
+
+                if (rule.debug) {
+                    const vaultName = this.app.vault.getName();
+                    new Notice(`DEBUG: ${file.basename} would be moved to ${vaultName}/${rule.destination}`);
                     return;
                 }
 
@@ -117,6 +124,14 @@ class RuleSettingTab extends PluginSettingTab {
                         rule.destination = value;
                         await this.plugin.saveData(this.plugin.settings);
                     }));
+            setting.addToggle(toggle =>
+                toggle
+                    .setTooltip('Enable debug mode')
+                    .setValue(rule.debug ?? false)
+                    .onChange(async (value) => {
+                        rule.debug = value;
+                        await this.plugin.saveData(this.plugin.settings);
+                    }));
             setting.addButton(btn =>
                 btn
                     .setButtonText('Remove')
@@ -132,7 +147,7 @@ class RuleSettingTab extends PluginSettingTab {
                 btn
                     .setButtonText('Add Rule')
                     .onClick(async () => {
-                        this.plugin.settings.rules.push({ key: '', value: '', destination: '' });
+                        this.plugin.settings.rules.push({ key: '', value: '', destination: '', debug: false });
                         await this.plugin.saveData(this.plugin.settings);
                         this.display();
                     }));

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -4,6 +4,7 @@ export interface FrontmatterRule {
     key: string;
     value: string | RegExp;
     destination: string;
+    debug?: boolean;
 }
 
 export interface SerializedFrontmatterRule {
@@ -12,6 +13,7 @@ export interface SerializedFrontmatterRule {
     destination: string;
     isRegex?: boolean;
     flags?: string;
+    debug?: boolean;
 }
 
 export function matchFrontmatter(this: { app: App }, file: TFile, rules: FrontmatterRule[]): FrontmatterRule | undefined {
@@ -42,12 +44,14 @@ export function serializeFrontmatterRules(rules: FrontmatterRule[]): SerializedF
                 destination: rule.destination,
                 isRegex: true,
                 flags: rule.value.flags,
+                debug: rule.debug,
             };
         }
         return {
             key: rule.key,
             value: rule.value,
             destination: rule.destination,
+            debug: rule.debug,
         };
     });
 }
@@ -57,6 +61,7 @@ export function deserializeFrontmatterRules(data: SerializedFrontmatterRule[] = 
         key: rule.key,
         value: rule.isRegex ? new RegExp(rule.value, rule.flags) : rule.value,
         destination: rule.destination,
+        debug: rule.debug,
     }));
 }
 


### PR DESCRIPTION
## Summary
- allow each frontmatter rule to run in debug mode, showing a notice instead of moving files
- expose per-rule debug toggle in settings UI
- document debug mode in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b4401be908326a89df6efb29a8988