### PR TITLE
test: add matchFrontmatter unit tests

### DIFF
--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -1,0 +1,56 @@
+import { matchFrontmatter, FrontmatterRule } from '../src/rules';
+import type { App, TFile } from 'obsidian';
+
+describe('matchFrontmatter', () => {
+  let app: App;
+  let metadataCache: { getFileCache: jest.Mock };
+  let file: TFile;
+
+  beforeEach(() => {
+    metadataCache = { getFileCache: jest.fn() };
+    app = { metadataCache } as unknown as App;
+    file = { path: 'Test.md' } as TFile;
+  });
+
+  it('matches exact string values', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', value: 'journal', destination: 'Journal' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
+
+  it('matches regex values', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'Journal' } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', value: /journal/i, destination: 'Journal' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
+
+  it('returns undefined when no frontmatter or missing keys', () => {
+    metadataCache.getFileCache.mockReturnValue({});
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', value: 'journal', destination: 'Journal' }
+    ];
+    const resultNoFrontmatter = matchFrontmatter.call({ app }, file, rules);
+    expect(resultNoFrontmatter).toBeUndefined();
+
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: {} });
+    const resultMissingKey = matchFrontmatter.call({ app }, file, rules);
+    expect(resultMissingKey).toBeUndefined();
+  });
+
+  it('returns the first matching rule when multiple rules match', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', value: 'note', destination: 'Note' },
+      { key: 'tag', value: 'journal', destination: 'Journal' },
+      { key: 'tag', value: /journal/, destination: 'JournalRegex' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[1]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for matchFrontmatter covering string matches, regex, undefined frontmatter, and multiple rule order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b4ee17bf08326849d834747658bbc