### PR TITLE
test: add handleFileChange tests

### DIFF
--- a/tests/main.handleFileChange.test.ts
+++ b/tests/main.handleFileChange.test.ts
@@ -1,0 +1,87 @@
+jest.mock('obsidian', () => {
+  const noticeMock = jest.fn();
+  class TFile {
+    path: string;
+    name: string;
+    basename: string;
+    extension: string;
+    constructor(path: string) {
+      this.path = path;
+      this.name = path.split('/').pop()!;
+      const parts = this.name.split('.');
+      this.basename = parts.slice(0, -1).join('.') || this.name;
+      this.extension = parts.length > 1 ? parts.pop()! : '';
+    }
+  }
+  return {
+    App: class {},
+    Plugin: class {
+      app: any;
+      constructor(app: any) { this.app = app; }
+      loadData() { return Promise.resolve(undefined); }
+      saveData() { return Promise.resolve(); }
+      addSettingTab() {}
+      registerEvent() {}
+    },
+    TFile,
+    normalizePath: (p: string) => require('path').posix.normalize(p.replace(/\\/g, '/')),
+    Notice: noticeMock,
+    PluginSettingTab: class { constructor(app: any, plugin: any) {} },
+    Setting: class {},
+    TAbstractFile: class {},
+  };
+}, { virtual: true });
+
+import VaultOrganizer from '../main';
+import { TFile, Notice } from 'obsidian';
+
+describe('handleFileChange', () => {
+  let metadataCache: { getFileCache: jest.Mock };
+  let renameFile: jest.Mock;
+  let plugin: VaultOrganizer;
+  let handle: (file: any) => Promise<void>;
+
+  beforeEach(async () => {
+    metadataCache = { getFileCache: jest.fn() };
+    renameFile = jest.fn().mockResolvedValue(undefined);
+    const vault = {
+      on: jest.fn((_: string, cb: any) => { handle = cb; }),
+      getName: jest.fn().mockReturnValue('Vault'),
+    };
+    const app = { metadataCache, fileManager: { renameFile }, vault } as any;
+    plugin = new VaultOrganizer(app);
+    plugin.addSettingTab = jest.fn();
+    await plugin.onload();
+    (Notice as jest.Mock).mockClear();
+  });
+
+  it('renames file when rule matches', async () => {
+    plugin.rules = [{ key: 'tag', value: 'journal', destination: 'Journal/' }];
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
+    const file = new TFile('Temp/Test.md');
+    await handle(file);
+    expect(renameFile).toHaveBeenCalledWith(file, 'Journal/Test.md');
+  });
+
+  it('emits notice and skips rename when rule is debug', async () => {
+    plugin.rules = [{ key: 'tag', value: 'journal', destination: 'Journal', debug: true }];
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
+    const file = new TFile('Temp/Test.md');
+    await handle(file);
+    expect(renameFile).not.toHaveBeenCalled();
+    expect(Notice).toHaveBeenCalledWith('DEBUG: Test would be moved to Vault/Journal');
+  });
+
+  it('ignores non-matching or same-path files', async () => {
+    plugin.rules = [{ key: 'tag', value: 'journal', destination: 'Journal' }];
+
+    metadataCache.getFileCache.mockReturnValueOnce({ frontmatter: { tag: 'note' } });
+    await handle(new TFile('Temp/Test.md'));
+
+    metadataCache.getFileCache.mockReturnValueOnce({ frontmatter: { tag: 'journal' } });
+    await handle(new TFile('Journal/Test.md'));
+
+    expect(renameFile).not.toHaveBeenCalled();
+    expect(Notice).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for handleFileChange covering rename, debug notice, and ignored files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b74b2499483269a8b39c3cff71086