### PR TITLE
Handle array frontmatter matching

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -27,11 +27,16 @@ export function matchFrontmatter(this: { app: App }, file: TFile, rules: Frontma
         if (value === undefined || value === null) {
             return false;
         }
-        const valueStr = String(value);
-        if (rule.value instanceof RegExp) {
-            return rule.value.test(valueStr);
-        }
-        return valueStr === rule.value;
+
+        const values = Array.isArray(value) ? value : [value];
+
+        return values.some(item => {
+            const valueStr = String(item);
+            if (rule.value instanceof RegExp) {
+                return rule.value.test(valueStr);
+            }
+            return valueStr === rule.value;
+        });
     });
 }
 

--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -53,4 +53,31 @@ describe('matchFrontmatter', () => {
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[1]);
   });
+
+  it('matches when frontmatter values are arrays of strings', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['work', 'journal'] } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tags', value: 'journal', destination: 'Journal Folder' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
+
+  it('matches when array values include mixed scalar types', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['daily', 42, true] } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tags', value: '42', destination: 'Numbers' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
+
+  it('matches regex rules against array elements', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['Work', 'Journal'] } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tags', value: /journal/i, destination: 'Journal Regex' }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- update frontmatter matching to evaluate array values element-wise for string and regex rules
- add unit coverage for string arrays, mixed scalar arrays, and regex matching against array elements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd6e9bc9ec8326911aa7af2501b8b8