### PR TITLE
Handle invalid regex when deserializing frontmatter rules

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -62,11 +62,34 @@ export function serializeFrontmatterRules(rules: FrontmatterRule[]): SerializedF
 }
 
 export function deserializeFrontmatterRules(data: SerializedFrontmatterRule[] = []): FrontmatterRule[] {
-    return data.map(rule => ({
-        key: rule.key,
-        value: rule.isRegex ? new RegExp(rule.value, rule.flags) : rule.value,
-        destination: rule.destination,
-        debug: rule.debug,
-    }));
+    const rules: FrontmatterRule[] = [];
+
+    for (const rule of data) {
+        if (rule.isRegex) {
+            try {
+                const regex = new RegExp(rule.value, rule.flags);
+                rules.push({
+                    key: rule.key,
+                    value: regex,
+                    destination: rule.destination,
+                    debug: rule.debug,
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                const destinationInfo = rule.destination ? ` (destination: "${rule.destination}")` : '';
+                const warningMessage = `[Obsidian Vault Organizer] Failed to deserialize regex for frontmatter rule "${rule.key}"${destinationInfo}: ${message}. Rule will be ignored.`;
+                console.warn(warningMessage);
+            }
+        } else {
+            rules.push({
+                key: rule.key,
+                value: rule.value,
+                destination: rule.destination,
+                debug: rule.debug,
+            });
+        }
+    }
+
+    return rules;
 }
 

--- a/tests/rules.serialization.test.ts
+++ b/tests/rules.serialization.test.ts
@@ -1,4 +1,9 @@
-import { serializeFrontmatterRules, deserializeFrontmatterRules, FrontmatterRule } from '../src/rules';
+import {
+  serializeFrontmatterRules,
+  deserializeFrontmatterRules,
+  FrontmatterRule,
+  SerializedFrontmatterRule
+} from '../src/rules';
 
 describe('Frontmatter rule serialization', () => {
   it('round-trips plain string rules', () => {
@@ -30,5 +35,19 @@ describe('Frontmatter rule serialization', () => {
     ];
     const result = deserializeFrontmatterRules(serializeFrontmatterRules(rules));
     expect(result[0].debug).toBe(true);
+  });
+
+  it('ignores malformed regex data during deserialization', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const malformed: SerializedFrontmatterRule[] = [
+        { key: 'tag', value: '\\', destination: 'Journal', isRegex: true }
+      ];
+      const result = deserializeFrontmatterRules(malformed);
+      expect(result).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to deserialize regex'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- wrap frontmatter rule regex deserialization in a try/catch to log and skip invalid patterns so the plugin keeps running
- extend the rules serialization test suite with coverage for malformed regex data being ignored

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cdbe8aab18832692860380a40611b1