### PR TITLE
Prevent renames when rule destinations are blank

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -50,15 +50,24 @@ export default class VaultOrganizer extends Plugin {
                     return;
                 }
 
-                const destinationFolder = normalizePath(rule.destination);
-                const newPath = normalizePath(`${rule.destination}/${file.name}`);
+                const trimmedDestination = rule.destination.trim();
+                if (!trimmedDestination) {
+                    if (rule.debug) {
+                        const vaultName = this.app.vault.getName();
+                        new Notice(`DEBUG: ${file.basename} would not be moved because destination is empty in ${vaultName}.`);
+                    }
+                    return;
+                }
+
+                const destinationFolder = normalizePath(trimmedDestination);
+                const newPath = normalizePath(`${trimmedDestination}/${file.name}`);
                 if (file.path === newPath) {
                     return;
                 }
 
                 if (rule.debug) {
                     const vaultName = this.app.vault.getName();
-                    new Notice(`DEBUG: ${file.basename} would be moved to ${vaultName}/${rule.destination}`);
+                    new Notice(`DEBUG: ${file.basename} would be moved to ${vaultName}/${trimmedDestination}`);
                     return;
                 }
 
@@ -133,7 +142,9 @@ class RuleSettingTab extends PluginSettingTab {
         containerEl.empty();
 
         this.plugin.settings.rules.forEach((rule, index) => {
-            const setting = new Setting(containerEl).setName(`Rule ${index + 1}`);
+            const setting = new Setting(containerEl)
+                .setName(`Rule ${index + 1}`)
+                .setDesc('Destination folder is required before the rule can move files.');
             setting.addText(text =>
                 text
                     .setPlaceholder('key')
@@ -160,7 +171,7 @@ class RuleSettingTab extends PluginSettingTab {
                     }));
             setting.addText(text =>
                 text
-                    .setPlaceholder('destination')
+                    .setPlaceholder('destination folder (required)')
                     .setValue(rule.destination)
                     .onChange(async (value) => {
                         const currentRule = this.plugin.settings.rules[index];

--- a/tests/main.handleFileChange.test.ts
+++ b/tests/main.handleFileChange.test.ts
@@ -27,7 +27,13 @@ jest.mock('obsidian', () => {
     normalizePath: (p: string) => require('path').posix.normalize(p.replace(/\\/g, '/')),
     Notice: noticeMock,
     PluginSettingTab: class { constructor(app: any, plugin: any) {} },
-    Setting: class {},
+    Setting: class {
+      setName() { return this; }
+      setDesc() { return this; }
+      addText() { return this; }
+      addToggle() { return this; }
+      addButton() { return this; }
+    },
     TAbstractFile: class {},
   };
 }, { virtual: true });
@@ -77,6 +83,15 @@ describe('handleFileChange', () => {
     const file = new TFile('Temp/Test.md');
     await handle(file);
     expect(renameFile).toHaveBeenCalledWith(file, 'Journal/Test.md');
+  });
+
+  it('skips rename when destination is blank', async () => {
+    await addRuleViaSettings({ key: 'tag', value: 'journal', destination: '   ' });
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
+    const file = new TFile('Temp/Test.md');
+    await handle(file);
+    expect(renameFile).not.toHaveBeenCalled();
+    expect(Notice).not.toHaveBeenCalled();
   });
 
   it('emits notice and skips rename when rule is debug', async () => {

--- a/tests/settings.ui.test.ts
+++ b/tests/settings.ui.test.ts
@@ -30,6 +30,7 @@ jest.mock('obsidian', () => {
       containerEl.appendChild(this.settingEl);
     }
     setName(_name: string) { return this; }
+    setDesc(_desc: string) { return this; }
     addText(cb: (api: any) => void) {
       const input = document.createElement('input');
       input.type = 'text';
@@ -104,7 +105,7 @@ describe('settings UI', () => {
     expect(plugin.saveData).toHaveBeenLastCalledWith({ rules: [{ key: 'tag', value: 'journal', destination: '', debug: false }] });
     expect((plugin as any).rules).toEqual([{ key: 'tag', value: 'journal', destination: '', debug: false }]);
 
-    const destInput = await screen.findByPlaceholderText('destination') as HTMLInputElement;
+    const destInput = await screen.findByPlaceholderText('destination folder (required)') as HTMLInputElement;
     await fireEvent.input(destInput, { target: { value: 'Journal' } });
     expect(plugin.saveData).toHaveBeenCalledTimes(4);
     expect(plugin.saveData).toHaveBeenLastCalledWith({ rules: [{ key: 'tag', value: 'journal', destination: 'Journal', debug: false }] });


### PR DESCRIPTION
## Summary
- trim and validate rule destinations before performing a rename, including a debug notice when the destination is empty
- update the settings UI to communicate that the destination folder is required for a rule to run
- add regression coverage for blank destinations and adjust UI tests for the new placeholder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dbe518c46c83269ec3c7626f331822