### PR TITLE
Fix global regex handling for frontmatter matching

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -33,6 +33,7 @@ export function matchFrontmatter(this: { app: App }, file: TFile, rules: Frontma
         return values.some(item => {
             const valueStr = String(item);
             if (rule.value instanceof RegExp) {
+                rule.value.lastIndex = 0;
                 return rule.value.test(valueStr);
             }
             return valueStr === rule.value;

--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -80,4 +80,23 @@ describe('matchFrontmatter', () => {
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
   });
+
+  it('resets global regex rules between different notes', () => {
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', value: /journal/g, destination: 'Journal Global' }
+    ];
+
+    const fileA = { path: 'First.md' } as TFile;
+    const fileB = { path: 'Second.md' } as TFile;
+
+    metadataCache.getFileCache
+      .mockReturnValueOnce({ frontmatter: { tag: 'journal' } })
+      .mockReturnValueOnce({ frontmatter: { tag: 'journal' } });
+
+    const firstResult = matchFrontmatter.call({ app }, fileA, rules);
+    const secondResult = matchFrontmatter.call({ app }, fileB, rules);
+
+    expect(firstResult).toEqual(rules[0]);
+    expect(secondResult).toEqual(rules[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- reset regex state before matching frontmatter rules so global patterns work consistently
- add a regression test covering global regex rules across multiple notes

## Testing
- npm test -- rules.match.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68dbf2a03a5c832682d2efba7c7ade96