### PR TITLE
Add command to reapply organization rules

### DIFF
--- a/tests/settings.ui.test.ts
+++ b/tests/settings.ui.test.ts
@@ -12,6 +12,7 @@ jest.mock('obsidian', () => {
     saveData(_data: any) { return Promise.resolve(); }
     addSettingTab(_tab: any) {}
     registerEvent() {}
+    addCommand() {}
   }
 
   class PluginSettingTab {


### PR DESCRIPTION
## Summary
- extract the markdown file relocation logic into a reusable helper
- add a command and settings refresh hook to reorganize all markdown files using the defined rules
- extend tests to cover the new command and updated mocks

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68dc039baa8c832688726d11516c8a8c