### PR TITLE
Decouple settings saves from reorganize trigger

### DIFF
--- a/tests/main.handleFileChange.test.ts
+++ b/tests/main.handleFileChange.test.ts
@@ -13,6 +13,40 @@ jest.mock('obsidian', () => {
       this.extension = parts.length > 1 ? parts.pop()! : '';
     }
   }
+  const debounce = <T extends (...args: any[]) => any>(fn: T, timeout = 0) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let lastArgs: Parameters<T> | null = null;
+    const debounced: any = (...args: Parameters<T>) => {
+      lastArgs = args;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        lastArgs && fn(...lastArgs);
+      }, timeout);
+      return debounced;
+    };
+    debounced.cancel = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      return debounced;
+    };
+    debounced.run = () => {
+      if (timer) {
+        clearTimeout(timer);
+        const args = lastArgs;
+        timer = null;
+        if (args) {
+          return fn(...args);
+        }
+      }
+    };
+    return debounced;
+  };
+
   return {
     App: class {},
     Plugin: class {
@@ -36,6 +70,7 @@ jest.mock('obsidian', () => {
       addButton() { return this; }
     },
     TAbstractFile: class {},
+    debounce,
   };
 }, { virtual: true });
 


### PR DESCRIPTION
## Summary
- add a save-only settings persistence path and reuse it from debounced text inputs while reserving reorganize for explicit actions
- introduce an "Apply now" control and update toggles and rule actions to call the reorganize-aware path
- extend UI tests to cover the new debounce behaviour and reorganize triggers while adapting existing mocks for the debounce helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd2a0b36d88326bbe5eab17b6755dd