### PR TITLE
Handle delayed frontmatter updates

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -48,6 +48,13 @@ export default class VaultOrganizer extends Plugin {
 
         this.registerEvent(this.app.vault.on('modify', handleFileChange));
         this.registerEvent(this.app.vault.on('create', handleFileChange));
+        this.registerEvent(this.app.metadataCache.on('changed', async (file) => {
+            if (!(file instanceof TFile) || file.extension !== 'md') {
+                return;
+            }
+
+            await this.applyRulesToFile(file);
+        }));
 
         this.addCommand({
             id: 'obsidian-vault-organizer-apply-rules',

--- a/tests/settings.ui.test.ts
+++ b/tests/settings.ui.test.ts
@@ -127,7 +127,11 @@ describe('settings UI', () => {
   beforeEach(async () => {
     jest.useFakeTimers();
     (Notice as jest.Mock).mockClear();
-    const app = { metadataCache: {}, fileManager: {}, vault: { on: jest.fn() } } as any;
+    const app = {
+      metadataCache: { on: jest.fn().mockReturnValue({}), getFileCache: jest.fn() },
+      fileManager: {},
+      vault: { on: jest.fn() },
+    } as any;
     plugin = new VaultOrganizer(app);
     plugin.saveData = jest.fn().mockResolvedValue(undefined);
     reorganizeSpy = jest


### PR DESCRIPTION
## Summary
- register a metadata cache change listener so rules run once frontmatter is available
- extend handleFileChange tests to cover delayed frontmatter and metadata cache wiring
- stub metadata cache listeners in UI tests to satisfy the new registration

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68dd985865288326ac5365efb34791b2