### PR TITLE
Add tag picker to rule value settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.ts']
+  testMatch: ['**/tests/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };


### PR DESCRIPTION
## Summary
- aggregate vault tags in the settings tab and refresh the cache when metadata resolves
- add a tag picker button that opens a fuzzy modal and toggles tags in the value field
- extend the settings UI test suite and adjust Jest resolution to cover the new picker behavior

## Testing
- npm test -- settings.ui.test.ts --runInBand --silent

------
https://chatgpt.com/codex/tasks/task_b_68deb1c7f5e48326a02421580a9b8096