### PR TITLE
Add match type operators to frontmatter rules

### DIFF
--- a/tests/main.handleFileChange.test.ts
+++ b/tests/main.handleFileChange.test.ts
@@ -73,6 +73,10 @@ jest.mock('obsidian', () => {
       addToggle() { return this; }
       addButton() { return this; }
     },
+    FuzzySuggestModal: class {
+      constructor(_app: any) {}
+      open() {}
+    },
     TAbstractFile: class {},
     debounce,
   };

--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -15,7 +15,7 @@ describe('matchFrontmatter', () => {
   it('matches exact string values', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
     const rules: FrontmatterRule[] = [
-      { key: 'tag', value: 'journal', destination: 'Journal' }
+      { key: 'tag', matchType: 'equals', value: 'journal', destination: 'Journal' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
@@ -24,16 +24,28 @@ describe('matchFrontmatter', () => {
   it('matches regex values', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'Journal' } });
     const rules: FrontmatterRule[] = [
-      { key: 'tag', value: /journal/i, destination: 'Journal' }
+      { key: 'tag', matchType: 'regex', value: /journal/i, destination: 'Journal' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
   });
 
+  it('matches using contains/starts-with/ends-with operators', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal-entry' } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tag', matchType: 'contains', value: 'journal', destination: 'Contains' },
+      { key: 'tag', matchType: 'starts-with', value: 'journal', destination: 'StartsWith' },
+      { key: 'tag', matchType: 'ends-with', value: 'entry', destination: 'EndsWith' },
+    ];
+    expect(matchFrontmatter.call({ app }, file, [rules[0]])).toEqual(rules[0]);
+    expect(matchFrontmatter.call({ app }, file, [rules[1]])).toEqual(rules[1]);
+    expect(matchFrontmatter.call({ app }, file, [rules[2]])).toEqual(rules[2]);
+  });
+
   it('returns undefined when no frontmatter or missing keys', () => {
     metadataCache.getFileCache.mockReturnValue({});
     const rules: FrontmatterRule[] = [
-      { key: 'tag', value: 'journal', destination: 'Journal' }
+      { key: 'tag', matchType: 'equals', value: 'journal', destination: 'Journal' }
     ];
     const resultNoFrontmatter = matchFrontmatter.call({ app }, file, rules);
     expect(resultNoFrontmatter).toBeUndefined();
@@ -46,9 +58,9 @@ describe('matchFrontmatter', () => {
   it('returns the first matching rule when multiple rules match', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal' } });
     const rules: FrontmatterRule[] = [
-      { key: 'tag', value: 'note', destination: 'Note' },
-      { key: 'tag', value: 'journal', destination: 'Journal' },
-      { key: 'tag', value: /journal/, destination: 'JournalRegex' }
+      { key: 'tag', matchType: 'equals', value: 'note', destination: 'Note' },
+      { key: 'tag', matchType: 'equals', value: 'journal', destination: 'Journal' },
+      { key: 'tag', matchType: 'regex', value: /journal/, destination: 'JournalRegex' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[1]);
@@ -57,7 +69,7 @@ describe('matchFrontmatter', () => {
   it('matches when frontmatter values are arrays of strings', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['work', 'journal'] } });
     const rules: FrontmatterRule[] = [
-      { key: 'tags', value: 'journal', destination: 'Journal Folder' }
+      { key: 'tags', matchType: 'equals', value: 'journal', destination: 'Journal Folder' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
@@ -66,7 +78,7 @@ describe('matchFrontmatter', () => {
   it('matches when array values include mixed scalar types', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['daily', 42, true] } });
     const rules: FrontmatterRule[] = [
-      { key: 'tags', value: '42', destination: 'Numbers' }
+      { key: 'tags', matchType: 'equals', value: '42', destination: 'Numbers' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
@@ -75,7 +87,7 @@ describe('matchFrontmatter', () => {
   it('matches regex rules against array elements', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['Work', 'Journal'] } });
     const rules: FrontmatterRule[] = [
-      { key: 'tags', value: /journal/i, destination: 'Journal Regex' }
+      { key: 'tags', matchType: 'regex', value: /journal/i, destination: 'Journal Regex' }
     ];
     const result = matchFrontmatter.call({ app }, file, rules);
     expect(result).toEqual(rules[0]);
@@ -83,7 +95,7 @@ describe('matchFrontmatter', () => {
 
   it('resets global regex rules between different notes', () => {
     const rules: FrontmatterRule[] = [
-      { key: 'tag', value: /journal/g, destination: 'Journal Global' }
+      { key: 'tag', matchType: 'regex', value: /journal/g, destination: 'Journal Global' }
     ];
 
     const fileA = { path: 'First.md' } as TFile;


### PR DESCRIPTION
## Summary
- add configurable matchType metadata for frontmatter rules and migrate stored settings
- support equals/contains/starts-with/ends-with/regex matching in rule evaluation and the settings UI dropdown
- expand tests for serialization, matching, and UI interactions and update mocks for new dropdown control

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dec3512a60832683d3123c98dc8ae2