### PR TITLE
Handle multi-tag frontmatter rule values

### DIFF
--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -94,6 +94,15 @@ describe('matchFrontmatter', () => {
     expect(result).toEqual(rules[0]);
   });
 
+  it('matches any selected tag when rule values contain multiple tags', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['#journal', '#ideas'] } });
+    const rules: FrontmatterRule[] = [
+      { key: 'tags', matchType: 'equals', value: '#daily #ideas #todo', destination: 'Ideas', enabled: true }
+    ];
+    const result = matchFrontmatter.call({ app }, file, rules);
+    expect(result).toEqual(rules[0]);
+  });
+
   it('matches regex rules against array elements', () => {
     metadataCache.getFileCache.mockReturnValue({ frontmatter: { tags: ['Work', 'Journal'] } });
     const rules: FrontmatterRule[] = [


### PR DESCRIPTION
## Summary
- expand frontmatter rule matching to evaluate each selected tag against array values
- keep non-array behavior unchanged while preserving regex handling
- add coverage for matching multi-tag rules against array values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68deea25275483268695d48c4794b62e