### PR TITLE
Prevent empty partial match rules from matching frontmatter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -384,9 +384,18 @@ class RuleSettingTab extends PluginSettingTab {
 
             const refreshWarning = () => {
                 const error = this.plugin.getRuleErrorForIndex(index);
+                const currentRule = this.plugin.settings.rules[index];
+                const matchType = currentRule?.matchType ?? 'equals';
+                const requiresValue = matchType === 'contains' || matchType === 'starts-with' || matchType === 'ends-with';
+                const hasValue = typeof currentRule?.value === 'string' && currentRule.value.trim().length > 0;
+
                 if (error) {
                     setting.settingEl.classList.add('vault-organizer-rule-error');
                     warningEl.textContent = `Invalid regular expression: ${error.message}`;
+                    warningEl.style.display = '';
+                } else if (requiresValue && !hasValue) {
+                    setting.settingEl.classList.add('vault-organizer-rule-error');
+                    warningEl.textContent = 'Value is required for contains/starts-with/ends-with rules.';
                     warningEl.style.display = '';
                 } else {
                     setting.settingEl.classList.remove('vault-organizer-rule-error');
@@ -439,6 +448,7 @@ class RuleSettingTab extends PluginSettingTab {
                         }
                         currentRule.value = value;
                         this.scheduleSaveOnly();
+                        refreshWarning();
                     });
             });
             setting.addExtraButton(button =>
@@ -504,6 +514,7 @@ class RuleSettingTab extends PluginSettingTab {
                         this.cancelPendingSaveOnly();
                         await this.plugin.saveSettingsAndRefreshRules();
                         updateRegexControlsVisibility();
+                        refreshWarning();
                     });
             });
             setting.addText(text => {
@@ -586,9 +597,17 @@ class RuleSettingTab extends PluginSettingTab {
             const isEnabled = currentRule?.enabled ?? false;
             settingEl.classList.toggle('vault-organizer-rule-disabled', !isEnabled);
             const error = this.plugin.getRuleErrorForIndex(index);
+            const matchType = currentRule?.matchType ?? 'equals';
+            const requiresValue = matchType === 'contains' || matchType === 'starts-with' || matchType === 'ends-with';
+            const hasValue = typeof currentRule?.value === 'string' && currentRule.value.trim().length > 0;
+
             if (error) {
                 settingEl.classList.add('vault-organizer-rule-error');
                 warningEl.textContent = `Invalid regular expression: ${error.message}`;
+                warningEl.style.display = '';
+            } else if (requiresValue && !hasValue) {
+                settingEl.classList.add('vault-organizer-rule-error');
+                warningEl.textContent = 'Value is required for contains/starts-with/ends-with rules.';
                 warningEl.style.display = '';
             } else {
                 settingEl.classList.remove('vault-organizer-rule-error');

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -53,13 +53,17 @@ export function matchFrontmatter(this: { app: App }, file: TFile, rules: Frontma
         }
 
         const ruleCandidates = getRuleCandidates(String(rule.value), isArrayValue);
-        if (!ruleCandidates.length) {
+        const normalizedCandidates =
+            matchType === 'contains' || matchType === 'starts-with' || matchType === 'ends-with'
+                ? ruleCandidates.filter(candidate => candidate.length > 0)
+                : ruleCandidates;
+        if (!normalizedCandidates.length) {
             return false;
         }
 
         return values.some(item => {
             const valueStr = String(item);
-            return ruleCandidates.some(candidate => matchByType(valueStr, candidate, matchType));
+            return normalizedCandidates.some(candidate => matchByType(valueStr, candidate, matchType));
         });
     });
 }

--- a/tests/rules.match.test.ts
+++ b/tests/rules.match.test.ts
@@ -52,6 +52,18 @@ describe('matchFrontmatter', () => {
     expect(matchFrontmatter.call({ app }, file, [rules[2]])).toEqual(rules[2]);
   });
 
+  it('does not match partial rules with empty values', () => {
+    metadataCache.getFileCache.mockReturnValue({ frontmatter: { tag: 'journal-entry' } });
+    const baseRule = { key: 'tag', value: '', destination: 'Invalid', enabled: true } as const;
+    const containsRule: FrontmatterRule = { ...baseRule, matchType: 'contains' };
+    const startsWithRule: FrontmatterRule = { ...baseRule, matchType: 'starts-with' };
+    const endsWithRule: FrontmatterRule = { ...baseRule, matchType: 'ends-with' };
+
+    expect(matchFrontmatter.call({ app }, file, [containsRule])).toBeUndefined();
+    expect(matchFrontmatter.call({ app }, file, [startsWithRule])).toBeUndefined();
+    expect(matchFrontmatter.call({ app }, file, [endsWithRule])).toBeUndefined();
+  });
+
   it('returns undefined when no frontmatter or missing keys', () => {
     metadataCache.getFileCache.mockReturnValue({});
     const rules: FrontmatterRule[] = [


### PR DESCRIPTION
## Summary
- ignore empty rule values for contains/starts-with/ends-with frontmatter matches
- add regression tests covering empty-value partial match rules
- surface a settings warning when partial-match rules lack a value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e3d83ffa6883268a3ece2aa8197e1b